### PR TITLE
redirect to session['CAS_AFTER_LOGIN_SESSION_URL'] if it exists instead

### DIFF
--- a/flask_cas/routing.py
+++ b/flask_cas/routing.py
@@ -40,8 +40,11 @@ def login():
     if cas_token_session_key in flask.session:
 
         if validate(flask.session[cas_token_session_key]):
-            redirect_url = flask.url_for(
-                current_app.config['CAS_AFTER_LOGIN'])
+            if 'CAS_AFTER_LOGIN_SESSION_URL' in flask.session:
+                redirect_url = flask.session.pop('CAS_AFTER_LOGIN_SESSION_URL')
+            else:
+                redirect_url = flask.url_for(
+                    current_app.config['CAS_AFTER_LOGIN'])
         else:
             del flask.session[cas_token_session_key]
 


### PR DESCRIPTION
@cameronbwhite thanks for writing Flask-CAS. I was able to roll it into a flask app fairly easily.

I needed to preserve the request.path once a client auth'd. In my login_required decorator, I decided to add to the clients session the URL prior to the /login redirection. 

```
# my login_required decorator
def login_required(function):
    @wraps(function)
    def wrap(*args, **kwargs):
        if 'CAS_USERNAME' in session:
            cas_username = session['CAS_USERNAME']
            if is_account_allowed(cas_username):
                return function(*args, **kwargs)
            else:
                return redirect(url_for('denied'))
        else:
            session['CAS_AFTER_LOGIN_SESSION_URL'] = request.path
            return redirect(url_for('cas.login', _external=True))
    return wrap
```

Within routing.py I attempt to access that session variable and if it exists, use it instead of CAS_AFTER_LOGIN.

This allowed me to preserve and redirect the URL the client requested instead of redirecting to the static URL that CAS_AFTER_LOGIN provides.

Thanks again!