### PR TITLE
login required decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ configuration value.
 The `/logout/` route will redirect the user to the CAS logout page and
 the `username` will be removed from the session.
 
+For convenience you can use the `cas.login` and `cas.logout`
+functions to redirect users to the login and logout pages. 
+
+    ```python
+    from flask.ext.cas import login
+    from flask.ext.cas import logout
+    ```
+
+If you would like to require that a user is logged in before continuing
+you may use the `cas.login_required` method.
+
+    ```python
+    from flask.ext.cas import login_required
+
+    app.route('/foo')
+    @login_required
+    def foo():
+        pass
+    ```
+
 ### Configuration ###
 
 #### Required Configs ####
@@ -111,6 +131,7 @@ the `username` will be removed from the session.
 import flask
 from flask import Flask
 from flask.ext.cas import CAS
+from flask.ext.cas import login_required
 
 app = Flask(__name__)
 cas = CAS(app, '/cas')
@@ -118,6 +139,7 @@ app.config['CAS_SERVER'] = 'https://sso.pdx.edu'
 app.config['CAS_AFTER_LOGIN'] = 'route_root'
 
 @app.route('/')
+@login_required
 def route_root():
     return flask.render_template(
         'layout.html',

--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -70,7 +70,6 @@ class CAS(object):
         return flask.session.get(
             self.app.config['CAS_USERNAME_SESSION_KEY'], None)
 
-
     @property
     def token(self):
         return flask.session.get(

--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from . import routing
 
+from functools import wraps
 
 class CAS(object):
     """
@@ -80,3 +81,13 @@ def login():
 
 def logout():
     return flask.redirect(flask.url_for('cas.logout', _external=True))
+
+def login_required(function):
+    @wraps(function)
+    def wrap(*args, **kwargs):
+        if 'CAS_USERNAME' not in flask.session:
+            flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.path
+            return login()
+        else:
+            return function(*args, **kwargs)
+    return wrap

--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -74,3 +74,9 @@ class CAS(object):
     def token(self):
         return flask.session.get(
             self.app.config['CAS_TOKEN_SESSION_KEY'], None)
+
+def login():
+    return flask.redirect(flask.url_for('cas.login', _external=True))
+
+def logout():
+    return flask.redirect(flask.url_for('cas.logout', _external=True))


### PR DESCRIPTION
The login required decorator can be applied to ensure that users are logged in before continuing.

```py
from flask.ext.cas import login_required

app.route('/foo')
@login_required
def foo():
    pass
```