### PR TITLE
Fix link to CAS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to authenticate users without gaining access to a user's security
 credentials, such as a password. The name CAS also refers to a 
 software package that implements this protocol. 
 
-http://www.jasig.org/cas
+http://jasig.github.io/cas
 
 ## Demo ##
 


### PR DESCRIPTION
This is a fairly insignificant change, but Jasig has been renamed to Apereo, and the official CAS site has been moved to GitHub.

There is also https://www.apereo.org/projects/cas, but that doesn't give much info and the "Project Homepage" link on there points to the GitHub page in this PR.