### PR TITLE
Handle situation where cas:attributes key is not in the parsed xml dump

### DIFF
--- a/flask_cas/routing.py
+++ b/flask_cas/routing.py
@@ -122,15 +122,18 @@ def validate(ticket):
         current_app.logger.debug("valid")
         xml_from_dict = xml_from_dict["cas:serviceResponse"]["cas:authenticationSuccess"]
         username = xml_from_dict["cas:user"]
-        attributes = xml_from_dict["cas:attributes"]
 
-        if "cas:memberOf" in attributes:
-            attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
-            for group_number in range(0, len(attributes['cas:memberOf'])):
-                attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
+        if "cas:attributes" in xml_from_dict.keys():
+            attributes = xml_from_dict["cas:attributes"]
+
+            if "cas:memberOf" in attributes:
+                attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
+                for group_number in range(0, len(attributes['cas:memberOf'])):
+                    attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
+
+            flask.session[cas_attributes_session_key] = attributes
 
         flask.session[cas_username_session_key] = username
-        flask.session[cas_attributes_session_key] = attributes
     else:
         current_app.logger.debug("invalid")
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -163,3 +163,18 @@ class test_routing(unittest.TestCase):
                 self.app.config['CAS_ATTRIBUTES_SESSION_KEY'] not in flask.session)
             self.assertTrue(
                 self.app.config['CAS_TOKEN_SESSION_KEY'] not in flask.session)
+
+    @mock.patch.object(routing, 'urlopen',
+                       return_value=io.BytesIO(b'\n\n'))
+    @mock.patch.object(routing, 'parse',
+                       return_value={
+                           "cas:serviceResponse": {
+                               "cas:authenticationSuccess": {
+                                   "cas:user": "bob"
+                               }
+                           }
+                       })
+    def test_attributes_missing_from_cas_validation_response(self, m, n):
+        with self.app.test_request_context('/login/'):
+            ticket = '12345-abcdefg-cas'
+            self.assertEqual(routing.validate(ticket), True)


### PR DESCRIPTION
I ran into a situation where the 'attributes' key was missing from the xml returned by the CAS. Had to modify the code to allow for this.