### PR TITLE
Fixed error when attributes are empty

### DIFF
--- a/flask_cas/routing.py
+++ b/flask_cas/routing.py
@@ -124,7 +124,7 @@ def validate(ticket):
         username = xml_from_dict["cas:user"]
         attributes = xml_from_dict["cas:attributes"]
 
-        if "cas:memberOf" in attributes:
+        if attributes and "cas:memberOf" in attributes:
             attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
             for group_number in range(0, len(attributes['cas:memberOf'])):
                 attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')


### PR DESCRIPTION
On my implementation of CAS, there are no attributes which causes an issue. 

Response looks like:
\<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'\>
	\<cas:authenticationSuccess\>
		\<cas:user\>username\</cas:user\>
\<!-- Begin Ldap Attributes --\>
	\<cas:attributes\>	
	\</cas:attributes\>
\<!-- End Ldap Attributes --\>
	\</cas:authenticationSuccess\>
\</cas:serviceResponse\>





