### PR TITLE
Check if cas:attributes exists in xml_from_dict exists before trying …

### DIFF
--- a/flask_cas/routing.py
+++ b/flask_cas/routing.py
@@ -122,15 +122,17 @@ def validate(ticket):
         current_app.logger.debug("valid")
         xml_from_dict = xml_from_dict["cas:serviceResponse"]["cas:authenticationSuccess"]
         username = xml_from_dict["cas:user"]
-        attributes = xml_from_dict.get("cas:attributes", {})
-
-        if "cas:memberOf" in attributes:
-            attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
-            for group_number in range(0, len(attributes['cas:memberOf'])):
-                attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
-
         flask.session[cas_username_session_key] = username
-        flask.session[cas_attributes_session_key] = attributes
+
+        if "cas:attributes" in xml_from_dict:
+            attributes = xml_from_dict["cas:attributes"]
+
+            if "cas:memberOf" in attributes:
+                attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
+                for group_number in range(0, len(attributes['cas:memberOf'])):
+                    attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
+
+            flask.session[cas_attributes_session_key] = attributes
     else:
         current_app.logger.debug("invalid")
 


### PR DESCRIPTION
…to get the attributes or memberOf values in the event that the CAS server/services doesn't present attributes.

Saw the bug referenced in issue #31 in our environment, our CAS service doesn't present cas:attributes other than the login name.

This patch allowed for the attributes to be non-existent or missing. 
