### PR TITLE
(gh-31) Handle unregistered apps with no attributes

### DIFF
--- a/flask_cas/routing.py
+++ b/flask_cas/routing.py
@@ -122,15 +122,18 @@ def validate(ticket):
         current_app.logger.debug("valid")
         xml_from_dict = xml_from_dict["cas:serviceResponse"]["cas:authenticationSuccess"]
         username = xml_from_dict["cas:user"]
-        attributes = xml_from_dict.get("cas:attributes", {})
+        try:
+            attributes = xml_from_dict.get("cas:attributes", {})
 
-        if "cas:memberOf" in attributes:
-            attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
-            for group_number in range(0, len(attributes['cas:memberOf'])):
-                attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
-
+            if "cas:memberOf" in attributes:
+                attributes["cas:memberOf"] = attributes["cas:memberOf"].lstrip('[').rstrip(']').split(',')
+                for group_number in range(0, len(attributes['cas:memberOf'])):
+                    attributes['cas:memberOf'][group_number] = attributes['cas:memberOf'][group_number].lstrip(' ').rstrip(' ')
+        except KeyError:
+            attributes = {}
+        finally:
+            flask.session[cas_attributes_session_key] = attributes
         flask.session[cas_username_session_key] = username
-        flask.session[cas_attributes_session_key] = attributes
     else:
         current_app.logger.debug("invalid")
 


### PR DESCRIPTION
There was an uncaught error when cas:attributes was not included in the response from the CAS server. This would happen if CAS is not configured to pass any attributes to an unregistered service.