### PR TITLE
Update README with correct code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ install Flask-CAS in a virtualenv.
 
 ## Instructions ##
 
-After Flask-CAS is installed you will be able to import the `flask.ext.cas`
+After Flask-CAS is installed you will be able to import the `flask_cas`
 packages. There is only one thing you care about inside the package
 which is the `CAS` class.
 
 ```python
-from flask.ext.cas import CAS
+from flask_cas import CAS
 ```
 
 There are two ways to use the `CAS` class.
@@ -94,15 +94,15 @@ For convenience you can use the `cas.login` and `cas.logout`
 functions to redirect users to the login and logout pages. 
 
 ```python
-from flask.ext.cas import login
-from flask.ext.cas import logout
+from flask_cas import login
+from flask_cas import logout
 ```
 
 If you would like to require that a user is logged in before continuing
 you may use the `cas.login_required` method.
 
 ```python
-from flask.ext.cas import login_required
+from flask_cas import login_required
 
 app.route('/foo')
 @login_required
@@ -136,8 +136,8 @@ def foo():
 ```python
 import flask
 from flask import Flask
-from flask.ext.cas import CAS
-from flask.ext.cas import login_required
+from flask_cas import CAS
+from flask_cas import login_required
 
 app = Flask(__name__)
 cas = CAS(app, '/cas')

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ install Flask-CAS in a virtualenv.
 
 ## Instructions ##
 
+Before using Flask-CAS you will need to specify a `secret_key` for your
+app. This is used by the underlying Flask-Session dependency, so ensure
+it is secure (random and long). Output from /dev/urandom is a good 
+source for this value, or you can hash a non-predictable string.
+
 After Flask-CAS is installed you will be able to import the `flask_cas`
 packages. There is only one thing you care about inside the package
 which is the `CAS` class.
@@ -63,6 +68,7 @@ There are two ways to use the `CAS` class.
 
 ```python
 app = Flask(__name__)
+app.secret_key = 'something long and unique and random'
 CAS(app)
 ```
 
@@ -71,6 +77,7 @@ CAS(app)
 ```python
 cas = CAS()
 app = Flask(__name__)
+app.secret_key = 'something long and unique and random'
 cas.init_app(app)
 ```
 
@@ -116,6 +123,7 @@ def foo():
 
 |Key             | Description                              | Example              |
 |----------------|------------------------------------------|----------------------|
+|secret_key      | Unique secret key for Flask-Session      | 'something random'   |
 |CAS_SERVER      | URL of CAS                               | 'http://sso.pdx.edu' |  
 |CAS_AFTER_LOGIN | Endpoint to go to after successful login | 'root'               |
 
@@ -141,6 +149,7 @@ from flask_cas import login_required
 
 app = Flask(__name__)
 cas = CAS(app, '/cas')
+app.secret_key = 'something long and unique and random'
 app.config['CAS_SERVER'] = 'https://sso.pdx.edu' 
 app.config['CAS_AFTER_LOGIN'] = 'route_root'
 


### PR DESCRIPTION
1. The import notation has changed from `flask.ext.cas` to `flask_cas`. If using the old style, the app will throw the following extension but continue running.

```
/usr/local/lib/python2.7/dist-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.cas is deprecated, use flask_cas instead.
```

2. The app will throw an exception and fail to continue if `app.secret_key` is not defined. I've documented this in the README. It appears to originate from Flask-Session.