### PR TITLE
Use `request.full_path` instead of `request.path`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
 install:
   - python setup.py install
 # command to run tests

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ install Flask-CAS in a virtualenv.
 
 ## Instructions ##
 
-After Flask-CAS is installed you will be able to import the `flask.ext.cas`
+After Flask-CAS is installed you will be able to import the `flask_cas`
 packages. There is only one thing you care about inside the package
 which is the `CAS` class.
 
 ```python
-from flask.ext.cas import CAS
+from flask_cas import CAS
 ```
 
 There are two ways to use the `CAS` class.
@@ -94,15 +94,15 @@ For convenience you can use the `cas.login` and `cas.logout`
 functions to redirect users to the login and logout pages. 
 
 ```python
-from flask.ext.cas import login
-from flask.ext.cas import logout
+from flask_cas import login
+from flask_cas import logout
 ```
 
 If you would like to require that a user is logged in before continuing
 you may use the `cas.login_required` method.
 
 ```python
-from flask.ext.cas import login_required
+from flask_cas import login_required
 
 app.route('/foo')
 @login_required
@@ -136,8 +136,8 @@ def foo():
 ```python
 import flask
 from flask import Flask
-from flask.ext.cas import CAS
-from flask.ext.cas import login_required
+from flask_cas import CAS
+from flask_cas import login_required
 
 app = Flask(__name__)
 cas = CAS(app, '/cas')

--- a/flask_cas/__init__.py
+++ b/flask_cas/__init__.py
@@ -96,7 +96,7 @@ def login_required(function):
     @wraps(function)
     def wrap(*args, **kwargs):
         if 'CAS_USERNAME' not in flask.session:
-            flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.path
+            flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.full_path
             return login()
         else:
             return function(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
 
             .. code:: python
 
-                from flask.ext.cas import CAS
+                from flask_cas import CAS
 
                 CAS(app)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7,8 +7,8 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from flask.ext.cas import routing
-from flask.ext.cas import CAS
+from flask_cas import routing
+from flask_cas import CAS
 
 
 class test_routing(unittest.TestCase):


### PR DESCRIPTION
I have some problem with `flask.request.path` in [this line](https://github.com/cameronbwhite/Flask-CAS/blob/10ee70466ac9e71cec3602c1cd46f0566618f67e/flask_cas/__init__.py#L99)
Just like the way in [flask-login](https://github.com/maxcountryman/flask-login/blob/486c456907e307e363d0c334fb2c079d4fa25d55/flask_login/login_manager.py#L172): **flask-login** use the `request.url` which has the `query_string` in the path (THE **full_path**).

So, I propose to user `request.full_path` instead of `request.path`. Just like this:

```python
 flask.session['CAS_AFTER_LOGIN_SESSION_URL'] = flask.request.full_path
```